### PR TITLE
Fix #5: Cover SvnDumpInMemory in some tests

### DIFF
--- a/src/main/java/com/github/cstroe/svndumpgui/internal/transform/NodeRemove.java
+++ b/src/main/java/com/github/cstroe/svndumpgui/internal/transform/NodeRemove.java
@@ -39,7 +39,11 @@ public class NodeRemove extends AbstractSvnDumpMutator {
 
     @Override
     public void consume(SvnNode node) {
-        if(nodeMatches(node)) {
+        boolean nodeMatches = foundTargetRevision && !removedNode &&
+                action.equals(node.get(SvnNodeHeader.ACTION)) &&
+                path.equals(node.get(SvnNodeHeader.PATH));
+
+        if(nodeMatches) {
             removedNode = true;
             inRemovedNode = true;
             return;
@@ -65,12 +69,6 @@ public class NodeRemove extends AbstractSvnDumpMutator {
     public void endNode(SvnNode node) {
         inRemovedNode = false;
         super.endNode(node);
-    }
-
-    private boolean nodeMatches(SvnNode node) {
-        return foundTargetRevision && !removedNode &&
-                action.equals(node.get(SvnNodeHeader.ACTION)) &&
-                path.equals(node.get(SvnNodeHeader.PATH));
     }
 
     @Override

--- a/src/main/java/com/github/cstroe/svndumpgui/internal/writer/SvnDumpInMemory.java
+++ b/src/main/java/com/github/cstroe/svndumpgui/internal/writer/SvnDumpInMemory.java
@@ -31,11 +31,23 @@ public class SvnDumpInMemory extends AbstractSvnDumpWriter {
     }
 
     @Override
+    public void endRevision(SvnRevision revision) {
+        currentRevision = null;
+        super.endRevision(revision);
+    }
+
+    @Override
     public void consume(SvnNode node) {
         currentNode = new SvnNodeImpl(node);
         currentNode.setRevision(currentRevision);
         currentRevision.addNode(currentNode);
         super.consume(node);
+    }
+
+    @Override
+    public void endNode(SvnNode node) {
+        currentNode = null;
+        super.endNode(node);
     }
 
     @Override

--- a/src/main/java/com/github/cstroe/svndumpgui/internal/writer/SvnDumpInMemory.java
+++ b/src/main/java/com/github/cstroe/svndumpgui/internal/writer/SvnDumpInMemory.java
@@ -41,6 +41,7 @@ public class SvnDumpInMemory extends AbstractSvnDumpWriter {
     @Override
     public void consume(FileContentChunk chunk) {
         currentNode.addFileContentChunk(chunk);
+        super.consume(chunk);
     }
 
     public SvnDump getDump() {

--- a/src/test/java/com/github/cstroe/svndumpgui/internal/writer/SvnDumpInMemoryTest.java
+++ b/src/test/java/com/github/cstroe/svndumpgui/internal/writer/SvnDumpInMemoryTest.java
@@ -1,0 +1,73 @@
+package com.github.cstroe.svndumpgui.internal.writer;
+
+import com.github.cstroe.svndumpgui.api.FileContentChunk;
+import com.github.cstroe.svndumpgui.api.SvnDumpConsumer;
+import com.github.cstroe.svndumpgui.api.SvnDumpPreamble;
+import com.github.cstroe.svndumpgui.api.SvnNode;
+import com.github.cstroe.svndumpgui.api.SvnRevision;
+import com.github.cstroe.svndumpgui.generated.ParseException;
+import com.github.cstroe.svndumpgui.generated.SvnDumpFileParser;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.Sequence;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+public class SvnDumpInMemoryTest {
+
+    @Test
+    public void consumer_chain_is_continued() throws ParseException {
+        Mockery context = new Mockery();
+        SvnDumpConsumer chainedConsumer = context.mock(SvnDumpConsumer.class, "chainedConsumer");
+        final Sequence chainerConsumerSequence = context.sequence("chainedConsumerSequence");
+
+        context.checking(new Expectations() {{
+            // preamble
+            oneOf(chainedConsumer).consume(with(any(SvnDumpPreamble.class))); inSequence(chainerConsumerSequence);
+
+            // revision 0
+            oneOf(chainedConsumer).consume(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endRevision(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+
+            // revision 1
+            oneOf(chainedConsumer).consume(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).consume(with(any(SvnNode.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).consume(with(any(FileContentChunk.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endChunks(); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endNode(with(any(SvnNode.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endRevision(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+
+            // revision 2
+            oneOf(chainedConsumer).consume(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).consume(with(any(SvnNode.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).consume(with(any(FileContentChunk.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endChunks(); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endNode(with(any(SvnNode.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endRevision(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+
+            // revision 3
+            oneOf(chainedConsumer).consume(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).consume(with(any(SvnNode.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endNode(with(any(SvnNode.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endRevision(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+
+            // revision 4
+            oneOf(chainedConsumer).consume(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).consume(with(any(SvnNode.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).consume(with(any(FileContentChunk.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endChunks(); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endNode(with(any(SvnNode.class))); inSequence(chainerConsumerSequence);
+            oneOf(chainedConsumer).endRevision(with(any(SvnRevision.class))); inSequence(chainerConsumerSequence);
+
+            // finish
+            oneOf(chainedConsumer).finish(); inSequence(chainerConsumerSequence);
+        }});
+
+
+        final InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream("dumps/add_edit_delete_add.dump");
+        SvnDumpInMemory inMemory = new SvnDumpInMemory();
+        inMemory.continueTo(chainedConsumer);
+        SvnDumpFileParser.consume(inputStream, inMemory);
+    }
+}


### PR DESCRIPTION
Wrote a unit test to cover SvnDumpInMemory chaining.

Also, use the endRevision, endNode methods to be more correct about managing `currentRevision` and `currentNode`.   This revealed a bug in `NodeRemove` that was patched here. 